### PR TITLE
Emit line number directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ MyClass::MyClass()
 ```cpp
 #pragma once
 
-//!GRAB example.h DECLARATION
+//! GRAB example.h DECLARATION
 
 #if defined(APP_IMPL)
-//!GRAB example.cpp IMPLEMENTATION
+//! GRAB example.cpp IMPLEMENTATION
 #undef APP_IMPL
 #endif
 ```

--- a/src_cpp/gimme-head.cpp
+++ b/src_cpp/gimme-head.cpp
@@ -62,12 +62,12 @@
 #include <vector>
 #include <string>
 #include <fstream>
-#include <sstream>
 #include <optional>
 #include <unordered_map>
-#include <unordered_set>
 #include <array>
 #include <filesystem>
+#include <algorithm>
+#include <list>
 
 // Database of all named code sections
 std::unordered_map<std::string, std::unordered_map<std::string, std::vector<std::string>>> mapCodeSections;

--- a/src_cpp/gimme-head.cpp
+++ b/src_cpp/gimme-head.cpp
@@ -68,6 +68,7 @@
 #include <filesystem>
 #include <algorithm>
 #include <list>
+#include <format>
 
 // Database of all named code sections
 std::unordered_map<std::string, std::unordered_map<std::string, std::vector<std::string>>> mapCodeSections;
@@ -182,9 +183,16 @@ int main(int argc, char* argv[])
 	if (vecArgs.size() < 3)
 	{
 		std::cout << "Error: Not enough arguments\n";
-		std::cout << "Usage: gimme-head template_filename output_filename\n";
+		std::cout << "Usage: gimme-head [--line-num] template_filename output_filename\n";
 
 		return -1;
+	}
+
+	bool bLineNum = false;
+	if (vecArgs.size() == 4 && vecArgs[1] == "--line-num")
+	{
+		bLineNum = true;
+		vecArgs.erase(vecArgs.begin() + 1);
 	}
 
 	// Argument 1 is the template file, so start there and discover
@@ -226,9 +234,11 @@ int main(int argc, char* argv[])
 
 		std::string sCurrentSectionName = "";
 		std::string sTargetFile = file;
+		unsigned int uLineNum = 0;
 
 		for (const auto& line : *f)
 		{
+			uLineNum++;
 			const auto tokens = ParseLine(line);
 			
 
@@ -257,9 +267,11 @@ int main(int argc, char* argv[])
 					}
 
 					std::unordered_map<std::string, std::vector<std::string>> section;
-					section.insert({ sCurrentSectionName, {} });
+					std::vector<std::string> lines;
+					if (bLineNum)
+						lines.push_back(std::format("#line {} \"{}\"", uLineNum + 1, file));
+					section.insert({ sCurrentSectionName, lines });
 					mapCodeSections.insert({ sTargetFile, section });
-					
 				}
 
 				else if (tokens[0] == "END")

--- a/src_cpp/gimme-head.cpp
+++ b/src_cpp/gimme-head.cpp
@@ -179,7 +179,7 @@ int main(int argc, char* argv[])
 	for (int i = 0; i < argc; i++)
 		vecArgs.push_back(argv[i]);
 
-	if (vecArgs.size() < 2)
+	if (vecArgs.size() < 3)
 	{
 		std::cout << "Error: Not enough arguments\n";
 		std::cout << "Usage: gimme-head template_filename output_filename\n";


### PR DESCRIPTION
This should make it easier to debug, as now the programmer is going to see the actual file names and line numbers that caused a particular error/warning. It's optional so "release" versions can be kept clean.

I'm not sure about style in variable names, let me know if anything needs fixing.

Also some minor fixes here and there