### PR TITLE
Add a simple cmake file and fix includes to build with gcc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@
 /.vs
 /msvc/.vs/olcGimmeHead
 /msvc/olcGimmeHead/x64/Debug
+
+# Local Cmake Definitions
+CMakePresets.json
+
+# build artifacts
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+project(olcGimmeHead)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(gimme-head)
+target_sources(gimme-head
+    PRIVATE
+    src_cpp/gimme-head.cpp
+)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # olcGimmeHead
 A simple guided text parser to combine multifile C++ projects into a single header include
 
+# Linux build
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+Tool should now be located at `build/gimme-head`.
+
 # Example
 `example.h`
 ```cpp

--- a/src_cpp/gimme-head.cpp
+++ b/src_cpp/gimme-head.cpp
@@ -58,16 +58,18 @@
 
 */
 
-#include <iostream>
-#include <vector>
-#include <string>
-#include <fstream>
-#include <sstream>
-#include <optional>
-#include <unordered_map>
-#include <unordered_set>
+#include <algorithm>
 #include <array>
 #include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <list>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 // Database of all named code sections
 std::unordered_map<std::string, std::unordered_map<std::string, std::vector<std::string>>> mapCodeSections;


### PR DESCRIPTION
Add some basic cmake support to make building the tool on non-windows platforms easier when working with pge3 development.